### PR TITLE
INFRASYS-6322 - Autoscaling down to original count when no new instan…

### DIFF
--- a/License2Deploy/rolling_deploy.py
+++ b/License2Deploy/rolling_deploy.py
@@ -133,6 +133,8 @@ class RollingDeploy(object):
 
     if not new_instances:
       logging.error("There are no instances in the group with build number {0}. Please ensure AMI was promoted.\nInstance ID List: {1}".format(build, id_list))
+      group_name = self.get_autoscale_group_name()
+      self.set_autoscale_instance_desired_count(self.calculate_autoscale_desired_instance_count(group_name, 'decrease'), group_name)
       exit(self.exit_error_code)
 
     id_ip_dict = self.get_instance_ip_addrs(new_instances)

--- a/tests/rolling_deploy_test.py
+++ b/tests/rolling_deploy_test.py
@@ -187,8 +187,10 @@ class RollingDeployTest(unittest.TestCase):
     self.assertEqual(len(instance_ids), len(rslt)) 
 
   @mock_ec2
+  @mock_autoscaling
   def test_get_instance_ids_by_requested_build_tag(self):
     self.setUpEC2()
+    self.setUpAutoScaleGroup()
     conn = boto.connect_ec2()
     new_inst = []
     res_ids = conn.get_all_instances()
@@ -197,6 +199,7 @@ class RollingDeployTest(unittest.TestCase):
          if [y for y in name.tags if y == 'BUILD' and name.tags['BUILD'] == '0']:
            new_inst.append(name.id)
     self.assertEqual(len(self.rolling_deploy.get_instance_ids_by_requested_build_tag(new_inst, 0)), 2)
+    self.assertRaises(SystemExit, lambda: self.rolling_deploy.get_instance_ids_by_requested_build_tag(new_inst, 1))
 
   @mock_ec2
   def test_get_instance_ids_by_requested_build_tag_failure(self):


### PR DESCRIPTION
…ces are in the load balancer

This will revert back to the original instance count if new instances come into the load balancer from the deployment but they aren't tagged with the new build.