### PR TITLE
(12.1.0) INFRASYS-6779 - disable the cloud-watch_alarms while rolling deployment.

### DIFF
--- a/License2Deploy/AWSConn.py
+++ b/License2Deploy/AWSConn.py
@@ -3,6 +3,7 @@
 import boto.ec2 as ec2
 import boto.ec2.autoscale as a
 import boto.ec2.elb as elb
+import boto.ec2.cloudwatch as cloudwatch
 import logging
 import yaml
 
@@ -28,6 +29,14 @@ class AWSConn(object):
   def aws_conn_elb(region, profile='default'):
     try:
       conn = elb.connect_to_region(region, profile_name=profile)
+      return conn
+    except Exception as e:
+      logging.error("Unable to connect to region, please investigate: {0}".format(e))
+
+  @staticmethod
+  def aws_conn_cloudwatch(region, profile='default'):
+    try: 
+      conn = cloudwatch.connect_to_region(region, profile_name=profile)
       return conn
     except Exception as e:
       logging.error("Unable to connect to region, please investigate: {0}".format(e))

--- a/tests/rolling_deploy_test.py
+++ b/tests/rolling_deploy_test.py
@@ -35,7 +35,7 @@ class RollingDeployTest(unittest.TestCase):
     }
 
   @mock_autoscaling
-  def setUpAutoScaleGroup(self, configurations):
+  def setUpAutoScaleGroup(self, configurations, env="stg"):
     conn = boto.connect_autoscale()
     for configuration in configurations:
       config = LaunchConfiguration(
@@ -43,6 +43,7 @@ class RollingDeployTest(unittest.TestCase):
         image_id='ami-abcd1234',
         instance_type='m1.medium',
       )
+      load_balancer_name = 'servergmsextenderELB{0}'.format(env)
       group = AutoScalingGroup(
         name=configuration[self.autoscaling_group_name],
         availability_zones=['us-east-1a'],
@@ -53,7 +54,7 @@ class RollingDeployTest(unittest.TestCase):
         max_size=10,
         min_size=2,
         launch_config=config,
-        load_balancers=['servergmsextenderELBstg'],
+        load_balancers=[load_balancer_name],
         vpc_zone_identifier='subnet-1234abcd',
         termination_policies=["Default"],
       )
@@ -185,9 +186,8 @@ class RollingDeployTest(unittest.TestCase):
     self.setUpELB(env='prd')
     self.rolling_deploy = RollingDeploy('prd', 'server-gms-extender', '0', 'ami-test212', None, './regions.yml')
     autoscaling_configurations = list()
-    autoscaling_configurations.append(self.get_autoscaling_configurations(self.GMS_LAUNCH_CONFIGURATION_STG, self.GMS_AUTOSCALING_GROUP_STG))
     autoscaling_configurations.append(self.get_autoscaling_configurations(self.GMS_LAUNCH_CONFIGURATION_PRD, self.GMS_AUTOSCALING_GROUP_PRD))
-    self.setUpAutoScaleGroup(autoscaling_configurations)
+    self.setUpAutoScaleGroup(autoscaling_configurations, env='prd')
     group = self.rolling_deploy.get_autoscale_group_name()
     self.assertEqual(group, self.GMS_AUTOSCALING_GROUP_PRD)
     self.assertNotEqual(group, self.GMS_AUTOSCALING_GROUP_STG)
@@ -215,6 +215,7 @@ class RollingDeployTest(unittest.TestCase):
   @mock_autoscaling
   @mock_elb
   def test_get_all_instance_ids(self):
+    self.setUpELB()
     self.setUpAutoScaleGroup([self.get_autoscaling_configurations(self.GMS_LAUNCH_CONFIGURATION_STG, self.GMS_AUTOSCALING_GROUP_STG)])
     conn = boto.connect_ec2()
     reservation = conn.run_instances('ami-1234abcd', min_count=2, private_ip_address="10.10.10.10")


### PR DESCRIPTION
Disabled the alarms before deployment
Enabled the alarms before deployment