### PR TITLE
(13.6.0) INFRASYS-7552 targets cloudwatch alarms specific to stack if stack_name is passed

### DIFF
--- a/tests/cloudformation_client_test.py
+++ b/tests/cloudformation_client_test.py
@@ -24,3 +24,8 @@ class CloudformationClientTest(unittest.TestCase):
         self.assertTrue(self.rolling_deploy.autoscaling_groups)
         self.assertEquals(asg_name, 'dnbi-backend-qa-servergmsextenderASGqa-QO8UAEHUFJD')
 
+    def test_retrieve_project_cloudwatch_alarms(self):
+        self.assertEquals(self.rolling_deploy.cloudwatch_alarms, False)
+        cloudwatch_alarms = self.rolling_deploy.retrieve_project_cloudwatch_alarms()
+        self.assertEquals(cloudwatch_alarms, ['dnbi-servergmsextender-SCALEDOWNALARMqa-123123', 'dnbi-servergmsextender-SCALEUPALARMqa-4asdhjks'])
+

--- a/tests/test_data/cloudformation.ListStackResources_1.json
+++ b/tests/test_data/cloudformation.ListStackResources_1.json
@@ -133,6 +133,70 @@
                 }, 
                 "ResourceStatus": "UPDATE_COMPLETE", 
                 "LogicalResourceId": "LC2"
+            },
+            {
+                "ResourceType": "AWS::CloudWatch::Alarm",
+                "PhysicalResourceId": "dnbi-servergmsextender-SCALEDOWNALARMqa-123123",
+                "LastUpdatedTimestamp": {
+                    "hour": 16,
+                    "__class__": "datetime",
+                    "month": 4,
+                    "second": 20,
+                    "microsecond": 217000,
+                    "year": 2016,
+                    "day": 6,
+                    "minute": 39
+                },
+                "ResourceStatus": "CREATE_COMPLETE",
+                "LogicalResourceId": "dnbiSCALEDOWNALARMqa"
+            },
+            {
+                "ResourceType": "AWS::CloudWatch::Alarm",
+                "PhysicalResourceId": "dnbi-servergmsextender-SCALEUPALARMqa-4asdhjks",
+                "LastUpdatedTimestamp": {
+                    "hour": 16,
+                    "__class__": "datetime",
+                    "month": 4,
+                    "second": 21,
+                    "microsecond": 108000,
+                    "year": 2016,
+                    "day": 6,
+                    "minute": 39
+                },
+                "ResourceStatus": "CREATE_COMPLETE",
+                "LogicalResourceId": "dnbiSCALEUPALARMqa"
+            },
+            {
+                "ResourceType": "AWS::CloudWatch::Alarm",
+                "PhysicalResourceId": "dnbi-projectbrave-SCALEDOWNALARMqa-asdasd123",
+                "LastUpdatedTimestamp": {
+                    "hour": 16,
+                    "__class__": "datetime",
+                    "month": 4,
+                    "second": 20,
+                    "microsecond": 217000,
+                    "year": 2016,
+                    "day": 6,
+                    "minute": 39
+                },
+                "ResourceStatus": "CREATE_COMPLETE",
+                "LogicalResourceId": "dnbiSCALEDOWNALARMqa"
+            },
+            {
+                "ResourceType": "AWS::CloudWatch::Alarm",
+                "PhysicalResourceId": "dnbi-projectbrave-SCALEUPALARMqa-4asdasdasda",
+                "LastUpdatedTimestamp": {
+                    "hour": 16,
+                    "__class__": "datetime",
+                    "month": 4,
+                    "second": 21,
+                    "microsecond": 108000,
+                    "year": 2016,
+                    "day": 6,
+                    "minute": 39
+                },
+                "ResourceStatus": "CREATE_COMPLETE",
+                "LogicalResourceId": "dnbiSCALEUPALARMqa"
             }
         ]
     }


### PR DESCRIPTION
Testing results:
```python
[root@aw1-slave-i6eb2282b121-ci License2Deploy]# su - jenkins-slave
-bash-4.1$ python /opt/License2Deploy/License2Deploy/rolling_deploy.py -e qa -p dnbi-cirrus -b 394 -P dnbi-deploy -a ami-f488ce94 -s dnbi-backend-qa
2016-07-12 15:20:17,440: INFO: Begin Logging...
2016-07-12 15:20:17,451: INFO: Found credentials in shared credentials file: ~/.aws/credentials
2016-07-12 15:20:17,614: INFO: Starting new HTTPS connection (1): cloudformation.us-west-1.amazonaws.com
2016-07-12 15:20:17,940: INFO: AMI ami-f488ce94 is ready
2016-07-12 15:20:17,940: INFO: Build #: 394 ::: Autoscale Group: dnbi-backend-qa-dnbicirrusASGqa-QICXCV5KS714
2016-07-12 15:20:18,102: INFO: Disabled cloud-watch alarm. dnbi-backend-qa-dnbicirrusSCALEDOWNALARMqa-1VNH3WQPHV1YF
2016-07-12 15:20:18,179: INFO: Disabled cloud-watch alarm. dnbi-backend-qa-dnbicirrusSCALEUPALARMqa-14IB7PKK2R1BM
2016-07-12 15:20:18,267: INFO: Current desired count was changed from 2 to 4
2016-07-12 15:20:18,267: INFO: Set autoscale capacity for dnbi-backend-qa-dnbicirrusASGqa-QICXCV5KS714 to 4
2016-07-12 15:20:18,308: INFO: Trying for maximum 10 minutes to allow for instances to be created.
2016-07-12 15:20:18,524: INFO: List of all Instance ID's and IP addresses in dnbi-backend-qa-dnbicirrusASGqa-QICXCV5KS714: {u'i-c2bf2587': u'10.30.10.205', u'i-c3bf2586': u'10.30.10.206'}
2016-07-12 15:20:18,524: INFO: Instance ID List: [u'i-c2bf2587', u'i-c3bf2586']
2016-07-12 15:20:18,657: INFO: New Instance List with IP Addresses: {u'i-c2bf2587': u'10.30.10.205', u'i-c3bf2586': u'10.30.10.206'}
2016-07-12 15:20:18,657: INFO: Waiting maximum 5 minutes for instances to be ready.
2016-07-12 15:20:18,713: INFO: i-c2bf2587 is in a healthy state. Moving on...
2016-07-12 15:20:18,795: INFO: i-c3bf2586 is in a healthy state. Moving on...
2016-07-12 15:20:18,795: INFO: Trying for maximum 5 minutes to health-check all instances.
2016-07-12 15:20:18,852: INFO: ELB healthcheck OK
2016-07-12 15:20:18,881: INFO: Current desired count was changed from 4 to 2
2016-07-12 15:20:18,882: INFO: Set autoscale capacity for dnbi-backend-qa-dnbicirrusASGqa-QICXCV5KS714 to 2
2016-07-12 15:20:18,940: INFO: Waiting maximum 5 minutes to terminate old instances.
2016-07-12 15:20:19,257: INFO: Deployed instances [InstanceState:(i-c2bf2587,InService), InstanceState:(i-c3bf2586,InService)] to ELB: dnbicirrusELBqa
2016-07-12 15:20:19,293: INFO: No tagging necessary, already tagged with env: qa
2016-07-12 15:20:19,293: INFO: Found an alarm. dnbi-backend-qa-dnbicirrusSCALEDOWNALARMqa-1VNH3WQPHV1YF
2016-07-12 15:20:19,409: INFO: Enabled cloud-watch alarm. dnbi-backend-qa-dnbicirrusSCALEDOWNALARMqa-1VNH3WQPHV1YF
2016-07-12 15:20:19,409: INFO: Found an alarm. dnbi-backend-qa-dnbicirrusSCALEUPALARMqa-14IB7PKK2R1BM
2016-07-12 15:20:19,479: INFO: Enabled cloud-watch alarm. dnbi-backend-qa-dnbicirrusSCALEUPALARMqa-14IB7PKK2R1BM
2016-07-12 15:20:19,479: INFO: Deployment Complete!
-bash-4.1$ 
```