### PR TITLE
DEVOPS-8639: increase wait time limit for instance health check

### DIFF
--- a/License2Deploy/rolling_deploy.py
+++ b/License2Deploy/rolling_deploy.py
@@ -24,7 +24,7 @@ class RollingDeploy(object):
                session=None,
                creation_wait=[10, 60],
                ready_wait=[10, 30],
-               health_wait=[10, 30],
+               health_wait=[40, 30],
                only_new_wait=[10, 30]):
     self.env = env
     self.session = session
@@ -397,7 +397,7 @@ def get_args(): # pragma: no cover
   parser.add_argument('-f', '--force-redeploy', action='store', dest='force_redeploy', help='Whether to force redeploy current running build', type=bool, default=False)
   parser.add_argument('-C', '--creation-wait', action='store', dest='creation_wait', help='Wait time for ec2 instance creation', type=int, nargs=2, default=[10, 60])
   parser.add_argument('-r', '--ready-wait', action='store', dest='ready_wait', help='Wait time for ec2 instance to be ready', type=int, nargs=2, default=[10, 30])
-  parser.add_argument('-H', '--health-wait', action='store', dest='health_wait', help='Wait time for ec2 instance health check', type=int, nargs=2, default=[10, 30])
+  parser.add_argument('-H', '--health-wait', action='store', dest='health_wait', help='Wait time for ec2 instance health check', type=int, nargs=2, default=[40, 30])
   parser.add_argument('-o', '--only-new-wait', action='store', dest='only_new_wait', help='Wait time for old ec2 instances to terminate', type=int, nargs=2, default=[10, 30])
   return parser.parse_args()
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ optional arguments:
                         e.g. -r 10 30
   -H HEALTH_WAIT, --health-wait HEALTH_WAIT
                         Time to wait for EC2 instances to be health checked
-                        (# of tries, interval of each try in seconds), default (10, 30)
-                        e.g. -H 10 30
+                        (# of tries, interval of each try in seconds), default (40, 30)
+                        e.g. -H 40 30
   -o ONLY_NEW_WAIT, --only-new-wait ONLY_NEW_WAIT
                         Time to wait for old EC2 instances to terminate
                         (# of tries, interval of each try in seconds), default (10, 30)


### PR DESCRIPTION
Increased the maximum wait time for health check to 20 minutes as some services such as `scoring` takes longer than 5 minutes to be ready.  This shouldn't affect existing deployment.