### PR TITLE
DEVOPS-9151: properly retrieve aws asg resources

### DIFF
--- a/tests/cloudformation_client_test.py
+++ b/tests/cloudformation_client_test.py
@@ -17,15 +17,15 @@ class CloudformationClientTest(unittest.TestCase):
         self.rolling_deploy = RollingDeploy('stg', 'server-gms-extender', '0', 'ami-abcd1234', None, './regions.yml', stack_name='test-stack-name', session=session)
 
     def test_get_autoscaling_group_name_via_cloudformation(self):
-        self.assertEquals(self.rolling_deploy.stack_resources, False)
-        self.assertEquals(self.rolling_deploy.autoscaling_groups, False)
+        self.assertEquals(self.rolling_deploy.autoscaling_group, False)
         asg_name = self.rolling_deploy.get_autoscale_group_name()
-        self.assertTrue(self.rolling_deploy.stack_resources)
-        self.assertTrue(self.rolling_deploy.autoscaling_groups)
-        self.assertEquals(asg_name, 'dnbi-backend-qa-servergmsextenderASGqa-QO8UAEHUFJD')
+        self.assertTrue(self.rolling_deploy.autoscaling_group)
+        self.assertEquals(asg_name, 'dnbi-backend-qa-dnbigmsextenderASGqa-1NP5ZBSVZRD0N')
 
     def test_retrieve_project_cloudwatch_alarms(self):
+        self.assertEquals(self.rolling_deploy.stack_resources, False)
         self.assertEquals(self.rolling_deploy.cloudwatch_alarms, False)
         cloudwatch_alarms = self.rolling_deploy.retrieve_project_cloudwatch_alarms()
+        self.assertTrue(self.rolling_deploy.stack_resources)
         self.assertEquals(cloudwatch_alarms, ['dnbi-servergmsextender-SCALEDOWNALARMqa-123123', 'dnbi-servergmsextender-SCALEUPALARMqa-4asdhjks'])
 

--- a/tests/rolling_deploy_test.py
+++ b/tests/rolling_deploy_test.py
@@ -6,10 +6,10 @@ import boto
 from boto.ec2.autoscale.launchconfig import LaunchConfiguration
 from boto.ec2.autoscale.group import AutoScalingGroup
 from boto.ec2.cloudwatch.alarm import MetricAlarm
-from moto import mock_autoscaling
-from moto import mock_ec2
-from moto import mock_elb
-from moto.cloudwatch import mock_cloudwatch
+from moto import mock_autoscaling_deprecated
+from moto import mock_ec2_deprecated
+from moto import mock_elb_deprecated
+from moto.cloudwatch import mock_cloudwatch_deprecated
 from nose.tools import raises
 
 from License2Deploy.rolling_deploy import RollingDeploy
@@ -26,9 +26,9 @@ class RollingDeployTest(unittest.TestCase):
   GMS_AUTOSCALING_GROUP_STG = 'server-backend-stg-servergmsextenderASGstg-3ELOD1FOTESTING'
   GMS_AUTOSCALING_GROUP_PRD = 'server-backend-prd-servergmsextenderASGprd-3ELOD1FOTESTING'
 
-  @mock_autoscaling
-  @mock_elb
-  @mock_ec2
+  @mock_autoscaling_deprecated
+  @mock_elb_deprecated
+  @mock_ec2_deprecated
   def setUp(self):
     self.setUpELB()
     self.rolling_deploy = RollingDeploy('stg', 'server-gms-extender', '0', 'ami-abcd1234', None, './regions.yml', force_redeploy=True)
@@ -39,7 +39,7 @@ class RollingDeployTest(unittest.TestCase):
       self.launch_configuration_name: launch_configuration_name
     }
 
-  @mock_autoscaling
+  @mock_autoscaling_deprecated
   def setUpAutoScaleGroup(self, configurations, env="stg"):
     conn = boto.connect_autoscale()
     for configuration in configurations:
@@ -66,7 +66,7 @@ class RollingDeployTest(unittest.TestCase):
       conn.create_launch_configuration(config)
       conn.create_auto_scaling_group(group)
 
-  @mock_elb
+  @mock_elb_deprecated
   def setUpELB(self, env='stg'):
     conn_elb = boto.connect_elb()
     zones = ['us-east-1a']
@@ -76,8 +76,8 @@ class RollingDeployTest(unittest.TestCase):
     balancers = conn_elb.get_all_load_balancers(load_balancer_names=[load_balancer_name])
     self.assertEqual(balancers[0].name, load_balancer_name)
 
-  @mock_ec2
-  @mock_elb
+  @mock_ec2_deprecated
+  @mock_elb_deprecated
   def setUpEC2(self, tag=True):
     self.setUpELB()
     conn_elb = boto.connect_elb()
@@ -96,7 +96,7 @@ class RollingDeployTest(unittest.TestCase):
 
     return [conn, instance_id_list]
 
-  @mock_cloudwatch
+  @mock_cloudwatch_deprecated
   def setUpCloudWatch(self, instance_ids, env="stg"):
     alarm = MetricAlarm(
       name = "servergmsextender_CloudWatchAlarm" + env,
@@ -114,7 +114,7 @@ class RollingDeployTest(unittest.TestCase):
     watch_conn = boto.connect_cloudwatch()
     watch_conn.put_metric_alarm(alarm)
 
-  @mock_cloudwatch
+  @mock_cloudwatch_deprecated
   def setUpCloudWatchWithWrongConfig(self, instance_ids, env="stg"):
     alarm = MetricAlarm(
       name = "servergmsextender_CloudWatchAlarm" + env,
@@ -131,8 +131,8 @@ class RollingDeployTest(unittest.TestCase):
     )
     watch_conn = boto.connect_cloudwatch()
     watch_conn.put_metric_alarm(alarm)
-    
-  @mock_cloudwatch
+
+  @mock_cloudwatch_deprecated
   def test_retrieve_project_cloudwatch_alarms(self):
     instance_ids = self.setUpEC2()
     self.setUpCloudWatch(instance_ids)
@@ -140,33 +140,33 @@ class RollingDeployTest(unittest.TestCase):
     print cloud_watch_alarms
     self.assertEqual(1, len(cloud_watch_alarms))
 
-  @mock_cloudwatch
+  @mock_cloudwatch_deprecated
   def test_retrieve_project_cloudwatch_alarms_with_no_valid_alarms(self):
     instance_ids = self.setUpEC2()
     self.setUpCloudWatch(instance_ids)
-    self.rolling_deploy.env = "wrong_env_prd" # set a wrong environment 
+    self.rolling_deploy.env = "wrong_env_prd" # set a wrong environment
     cloud_watch_alarms = self.rolling_deploy.retrieve_project_cloudwatch_alarms()
     self.assertEqual(0, len(cloud_watch_alarms))
 
-  @mock_cloudwatch
+  @mock_cloudwatch_deprecated
   def test_retrieve_project_cloudwatch_alarms_with_wrong_config(self):
     instance_ids = self.setUpEC2()
     self.setUpCloudWatchWithWrongConfig(instance_ids)
     self.assertRaises(SystemExit, lambda: self.rolling_deploy.retrieve_project_cloudwatch_alarms())
 
-  @mock_cloudwatch
+  @mock_cloudwatch_deprecated
   def test_enable_project_cloudwatch_alarms_Error(self):
     instance_ids = self.setUpEC2()
     self.setUpCloudWatch(instance_ids)
     self.assertRaises(SystemExit, lambda: self.rolling_deploy.enable_project_cloudwatch_alarms())
 
-  @mock_cloudwatch
+  @mock_cloudwatch_deprecated
   def test_disable_project_cloudwatch_alarms_Error(self):
     instance_ids = self.setUpEC2()
     self.setUpCloudWatch(instance_ids)
     self.assertRaises(SystemExit, lambda: self.rolling_deploy.disable_project_cloudwatch_alarms())
 
-  @mock_ec2
+  @mock_ec2_deprecated
   def test_tag_ami(self):
     conn = self.setUpEC2()[0]
     reservation = conn.run_instances('ami-1234xyz1', min_count=1)
@@ -180,7 +180,7 @@ class RollingDeployTest(unittest.TestCase):
     self.rolling_deploy.tag_ami(str(_ami_id), 'qa')
     self.assertRaises(SystemExit, lambda: self.rolling_deploy.tag_ami('blargness', 'qa'))
 
-  @mock_ec2
+  @mock_ec2_deprecated
   def test_load_config(self):
     self.assertEqual(AWSConn.load_config('regions.yml').get('qa'), 'us-west-1')
     self.assertEqual(AWSConn.load_config('regions.yml').get('stg'), 'us-east-1')
@@ -188,11 +188,11 @@ class RollingDeployTest(unittest.TestCase):
     self.assertEqual(AWSConn.load_config('regions.yml').get('default'), 'us-west-1')
     self.assertEqual(AWSConn.load_config('regions.yml').get('zero'), None)
 
-  @mock_ec2
+  @mock_ec2_deprecated
   def test_load_config(self):
     self.assertEqual(AWSConn.determine_region('get-shwifty'), 'us-west-1')
 
-  @mock_ec2
+  @mock_ec2_deprecated
   def test_wait_ami_availability(self):
     conn = self.setUpEC2()[0]
     inst_ids = self.setUpEC2()[1]
@@ -204,21 +204,21 @@ class RollingDeployTest(unittest.TestCase):
     self.assertRaises(SystemExit, lambda: self.rolling_deploy.wait_ami_availability('bad-id')) #Will raise exception because ami can't be found
     self.assertRaises(SystemExit, lambda: self.rolling_deploy.wait_ami_availability(ami_id.id, -100)) #Will raise exception as time limit is over
 
-  @mock_ec2
-  @mock_elb
+  @mock_ec2_deprecated
+  @mock_elb_deprecated
   def test_confirm_lb_has_only_new_instances(self):
     instance_ids = self.setUpEC2()[1]
     self.rolling_deploy.load_balancer = self.rolling_deploy.get_lb()
     self.assertEqual(len(instance_ids), len(self.rolling_deploy.confirm_lb_has_only_new_instances())) #Return All LB's with the proper build number
 
-  @mock_elb
+  @mock_elb_deprecated
   def test_get_lb(self):
     self.setUpELB()
     self.assertEqual(u'servergmsextenderELBstg', self.rolling_deploy.get_lb()) #Return All LB's with the proper build number
 
   # assertRaises is a context manager since Python 2.7. Only testing in Python 2.7
   # https://docs.python.org/2.7/library/unittest.html
-  @mock_elb
+  @mock_elb_deprecated
   def test_get_lb_failure(self):
     if sys.version_info >= (2, 7):
       self.setUpELB()
@@ -227,8 +227,8 @@ class RollingDeployTest(unittest.TestCase):
         bad_rolling_deploy.load_balancer = bad_rolling_deploy.get_lb()
       self.assertEqual(2, rolling_deploy.exception.code)
 
-  @mock_ec2
-  @mock_elb
+  @mock_ec2_deprecated
+  @mock_elb_deprecated
   def test_lb_healthcheck(self):
     instance_ids = self.setUpEC2()[1]
     self.assertTrue(self.rolling_deploy.lb_healthcheck(instance_ids)) #Return InService for all instances in ELB
@@ -237,18 +237,18 @@ class RollingDeployTest(unittest.TestCase):
     ## https://github.com/spulec/moto/blob/master/moto/elb/responses.py#L219 ##
     #self.assertRaises(SystemExit, lambda: self.rolling_deploy.lb_healthcheck(instance_ids, 1, 1)) #Return OutOfService for the first instance in the ELB which will raise an exit call
 
-  @mock_autoscaling
+  @mock_autoscaling_deprecated
   def test_get_group_info(self):
     self.setUpAutoScaleGroup([self.get_autoscaling_configurations(self.GMS_LAUNCH_CONFIGURATION_STG, self.GMS_AUTOSCALING_GROUP_STG)])
     group = self.rolling_deploy.get_group_info([self.GMS_AUTOSCALING_GROUP_STG])[0]
     self.assertEqual(group.name, self.GMS_AUTOSCALING_GROUP_STG)
 
-  @mock_autoscaling
+  @mock_autoscaling_deprecated
   def test_failure_get_group_info(self):
     self.setUpAutoScaleGroup([self.get_autoscaling_configurations(self.GMS_LAUNCH_CONFIGURATION_STG, self.GMS_AUTOSCALING_GROUP_STG)])
     self.assertRaises(SystemExit, lambda: self.rolling_deploy.get_group_info('cool'))
 
-  @mock_autoscaling
+  @mock_autoscaling_deprecated
   def test_get_autoscale_group_name_stg(self):
     autoscaling_configurations = list()
     autoscaling_configurations.append(self.get_autoscaling_configurations(self.GMS_LAUNCH_CONFIGURATION_STG, self.GMS_AUTOSCALING_GROUP_STG))
@@ -258,8 +258,8 @@ class RollingDeployTest(unittest.TestCase):
     self.assertEqual(group, self.GMS_AUTOSCALING_GROUP_STG)
     self.assertNotEqual(group, self.GMS_AUTOSCALING_GROUP_PRD)
 
-  @mock_autoscaling
-  @mock_elb
+  @mock_autoscaling_deprecated
+  @mock_elb_deprecated
   def test_get_autoscale_group_name_prd(self):
     self.setUpELB(env='prd')
     self.rolling_deploy = RollingDeploy('prd', 'server-gms-extender', '0', 'ami-test212', None, './regions.yml')
@@ -270,7 +270,7 @@ class RollingDeployTest(unittest.TestCase):
     self.assertEqual(group, self.GMS_AUTOSCALING_GROUP_PRD)
     self.assertNotEqual(group, self.GMS_AUTOSCALING_GROUP_STG)
 
-  @mock_autoscaling
+  @mock_autoscaling_deprecated
   def test_calculate_autoscale_desired_instance_count(self):
     self.setUpAutoScaleGroup([self.get_autoscaling_configurations(self.GMS_LAUNCH_CONFIGURATION_STG, self.GMS_AUTOSCALING_GROUP_STG)])
     increase = self.rolling_deploy.calculate_autoscale_desired_instance_count(self.GMS_AUTOSCALING_GROUP_STG, 'increase')
@@ -278,25 +278,25 @@ class RollingDeployTest(unittest.TestCase):
     self.assertEqual(increase, 4)
     self.assertEqual(decrease, 1)
 
-  @mock_autoscaling
+  @mock_autoscaling_deprecated
   def test_calculate_autoscale_desired_instance_count_failure(self):
     self.setUpAutoScaleGroup([self.get_autoscaling_configurations(self.GMS_LAUNCH_CONFIGURATION_STG, self.GMS_AUTOSCALING_GROUP_STG)])
     self.assertRaises(SystemExit, lambda: self.rolling_deploy.calculate_autoscale_desired_instance_count(self.GMS_AUTOSCALING_GROUP_STG, 'nothing'))
 
-  @mock_ec2
+  @mock_ec2_deprecated
   def test_get_instance_ip_addrs(self):
     self.setUpEC2()
     self.rolling_deploy.get_instance_ip_addrs(self.setUpEC2()[1])
     self.rolling_deploy.log_instances_ips(self.setUpEC2()[1], 'group')
     self.assertRaises(SystemExit, lambda: self.rolling_deploy.get_instance_ip_addrs(['blah', 'blarg']))
 
-  @mock_ec2
+  @mock_ec2_deprecated
   def test_is_redeploy(self):
     self.setUpEC2()
     self.assertTrue(self.rolling_deploy.is_redeploy())
 
   @raises(SystemExit)
-  @mock_ec2
+  @mock_ec2_deprecated
   def test_is_redeploy_fails(self):
     self.setUpEC2(tag=False)
     self.assertRaises(self.rolling_deploy.is_redeploy(), Exception)
@@ -305,9 +305,9 @@ class RollingDeployTest(unittest.TestCase):
   def test_stop_deploy(self):
     self.assertRaises(self.rolling_deploy.stop_deploy('error!'), Exception)
 
-  @mock_ec2
-  @mock_autoscaling
-  @mock_elb
+  @mock_ec2_deprecated
+  @mock_autoscaling_deprecated
+  @mock_elb_deprecated
   def test_get_all_instance_ids(self):
     self.setUpELB()
     self.setUpAutoScaleGroup([self.get_autoscaling_configurations(self.GMS_LAUNCH_CONFIGURATION_STG, self.GMS_AUTOSCALING_GROUP_STG)])
@@ -315,10 +315,10 @@ class RollingDeployTest(unittest.TestCase):
     reservation = conn.run_instances('ami-1234abcd', min_count=2, private_ip_address="10.10.10.10")
     instance_ids = reservation.instances
     rslt = self.rolling_deploy.get_all_instance_ids(self.GMS_AUTOSCALING_GROUP_STG)
-    self.assertEqual(len(instance_ids), len(rslt)) 
+    self.assertEqual(len(instance_ids), len(rslt))
 
-  @mock_ec2
-  @mock_autoscaling
+  @mock_ec2_deprecated
+  @mock_autoscaling_deprecated
   def test_get_instance_ids_by_requested_build_tag(self):
     self.setUpEC2()
     self.setUpAutoScaleGroup([self.get_autoscaling_configurations(self.GMS_LAUNCH_CONFIGURATION_STG, self.GMS_AUTOSCALING_GROUP_STG)])
@@ -340,8 +340,8 @@ class RollingDeployTest(unittest.TestCase):
     self.rolling_deploy.force_redeploy = True
     self.assertRaises(Exception, lambda: self.rolling_deploy.get_instance_ids_by_requested_build_tag(new_inst, 0))
 
-  @mock_ec2
-  @mock_autoscaling
+  @mock_ec2_deprecated
+  @mock_autoscaling_deprecated
   def test_get_instance_ids_by_requested_build_tag_race_condition(self):
     self.setUpEC2()
     self.setUpAutoScaleGroup([self.get_autoscaling_configurations(self.GMS_LAUNCH_CONFIGURATION_STG, self.GMS_AUTOSCALING_GROUP_STG)])
@@ -358,22 +358,22 @@ class RollingDeployTest(unittest.TestCase):
     self.assertRaises(Exception, lambda: self.rolling_deploy.get_instance_ids_by_requested_build_tag(new_inst, 1))
 
 
-  @mock_ec2
+  @mock_ec2_deprecated
   def test_get_instance_ids_by_requested_build_tag_failure(self):
     self.setUpEC2()
     self.assertRaises(Exception, lambda: self.rolling_deploy.get_instance_ids_by_requested_build_tag([], 0))
 
-  @mock_autoscaling
+  @mock_autoscaling_deprecated
   def test_set_autoscale_instance_desired_count(self):
     self.setUpAutoScaleGroup([self.get_autoscaling_configurations(self.GMS_LAUNCH_CONFIGURATION_STG, self.GMS_AUTOSCALING_GROUP_STG)])
     self.assertTrue(self.rolling_deploy.set_autoscale_instance_desired_count(4, self.GMS_AUTOSCALING_GROUP_STG))
 
-  @mock_ec2
+  @mock_ec2_deprecated
   def test_wait_for_new_instances(self):
     instance_ids = self.setUpEC2()[1]
     self.assertEqual(self.rolling_deploy.wait_for_new_instances(instance_ids, 9), None)
 
-  @mock_ec2
+  @mock_ec2_deprecated
   def test_wait_for_new_instances_failure(self):
     conn = self.setUpEC2()[0]
     instance_ids = self.setUpEC2()[1]

--- a/tests/test_data/cloudformation.DescribeStackResource_1.json
+++ b/tests/test_data/cloudformation.DescribeStackResource_1.json
@@ -1,0 +1,34 @@
+{
+    "status_code": 200, 
+    "data": {
+        "StackResourceDetail": {
+            "StackId": "arn:aws:cloudformation:us-west-1:186502235371:stack/dnbi-backend-qa/1d82ec90-4df3-11e6-a730-500c2171aef2", 
+            "ResourceStatus": "UPDATE_COMPLETE", 
+            "ResourceType": "AWS::AutoScaling::AutoScalingGroup", 
+            "LastUpdatedTimestamp": {
+                "hour": 17, 
+                "__class__": "datetime", 
+                "month": 5, 
+                "second": 2, 
+                "microsecond": 195000, 
+                "year": 2017, 
+                "day": 12, 
+                "minute": 23
+            }, 
+            "StackName": "dnbi-backend-qa", 
+            "PhysicalResourceId": "dnbi-backend-qa-dnbigmsextenderASGqa-1NP5ZBSVZRD0N", 
+            "Metadata": "{}\n", 
+            "LogicalResourceId": "dnbigmsextenderASGqa"
+        }, 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "f4818419-3b15-11e7-b606-7750501fb0b2", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "f4818419-3b15-11e7-b606-7750501fb0b2", 
+                "date": "Wed, 17 May 2017 15:31:54 GMT", 
+                "content-length": "921", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Tested with `dnbi-cache-qa`.  ASG name is properly retrieved.

![screen shot 2017-05-16 at 4 18 31 pm](https://cloud.githubusercontent.com/assets/9552992/26128820/5969eb12-3a53-11e7-9337-92a887774066.png)
