### PR TITLE
(18.37.0) DEVOPS-11430: Passes ELB Name to L2D

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,2 +1,3 @@
 v0.0.1 First working version
 v0.2.0 python 3 compatibility, add cli entrypoint
+v0.3.0 Updates to pass ASG and ELB names via command line

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 setup(
     name="License2Deploy",
-    version="0.2.0",
+    version="0.3.0",
     author="Dun and Bradstreet",
     author_email="license2deploy@dandb.com",
     description="Rolling deploys by changing desired amount of instances AWS EC2 Autoscale Group",


### PR DESCRIPTION
https://dunandb.jira.com/browse/DEVOPS-11430

Tested by updating ciq on saltmaster to point to this branch, then highstated ciq agent:
```
[root@ae1-saltmaster43-ci slave (release-next *)]# cat init.sls | grep -A 7 'License2Deploy:'
License2Deploy:
  pip.installed:
    - bin_env: /usr/bin/pip2.7
    - name: git+https://github.com/taoistmath/License2Deploy.git@DEVOPS-11430
    - upgrade: True
    - require:
      - file: {{ opt }}/License2Deploy/regions.yml
      - pkg: python27
```

```
----------
          ID: License2Deploy
    Function: pip.installed
        Name: git+https://github.com/taoistmath/License2Deploy.git@DEVOPS-11430
      Result: True
     Comment: All packages were successfully installed
     Started: 11:22:22.329608
    Duration: 1798.66 ms
     Changes:   
              ----------
              git+https://github.com/taoistmath/License2Deploy.git@DEVOPS-11430==???:
                  Installed
```

then updated cupdate-service_qa_deploy_ami with changes from Jenkins-jobs PR:
<img width="1214" alt="screen shot 2018-08-03 at 11 35 47 am" src="https://user-images.githubusercontent.com/588833/43659616-669707a4-9711-11e8-9cd2-2039d0c3d7d0.png">

Deployment was successful and used proper ELB:
<img width="1220" alt="screen shot 2018-08-03 at 11 36 18 am" src="https://user-images.githubusercontent.com/588833/43659657-81e76238-9711-11e8-8837-6e13b1901d52.png">

Final instances are the newest instances from the job:
![screen shot 2018-08-03 at 11 38 31 am](https://user-images.githubusercontent.com/588833/43659748-cdaa77dc-9711-11e8-9ea5-b0ee010e20de.png)
