### PR TITLE
DEVOPS-12154: ensures original instances are terminated whenever new …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 setup(
     name="License2Deploy",
-    version="0.3.0",
+    version="0.3.1",
     author="Dun and Bradstreet",
     author_email="license2deploy@dandb.com",
     description="Rolling deploys by changing desired amount of instances AWS EC2 Autoscale Group",


### PR DESCRIPTION
…instances are launched successfully.


Tested by updating salt state for pip installing License2Deploy to use my branch and highstated a jenkins agent with these changes:
```
[gfogelberg@REDACTED slave (release-next *)]# pwd
/srv/config/ciq/salt/ci/jenkins/slave
[gfogelberg@REDACTED slave (release-next *)]# grep -A 7 'License2Deploy:' init.sls
License2Deploy:
  pip.installed:
    - bin_env: /usr/bin/pip2.7
    - name: git+https://github.com/taoistmath/License2Deploy.git@DEVOPS-12154
    - upgrade: True
    - require:
      - file: {{ opt }}/License2Deploy/regions.yml
      - pkg: python27
```
```
[INFO    ] Running state [git+https://github.com/taoistmath/License2Deploy.git@DEVOPS-12154] at time 15:01:58.301542
[INFO    ] Executing state pip.installed for git+https://github.com/taoistmath/License2Deploy.git@DEVOPS-12154
[DEBUG   ] Installed pip version: 7.1.0
[INFO    ] Executing command ['/usr/bin/pip2.7', 'install', '--upgrade', 'git+https://github.com/taoistmath/License2Deploy.git@DEVOPS-12154'] in directory '/root'
[DEBUG   ] stdout: Downloading/unpacking git+https://github.com/taoistmath/License2Deploy.git@DEVOPS-12154
  Cloning https://github.com/taoistmath/License2Deploy.git (to DEVOPS-12154) to /tmp/pip-_nqiBd-build
  Running setup.py (path:/tmp/pip-_nqiBd-build/setup.py) egg_info for package from git+https://github.com/taoistmath/License2Deploy.git@DEVOPS-12154
    
Requirement already up-to-date: boto==2.48.0 in /usr/lib/python2.7/site-packages (from License2Deploy==0.3.0)
Requirement already up-to-date: boto3==1.7.37 in /usr/lib/python2.7/site-packages (from License2Deploy==0.3.0)
Requirement already up-to-date: PyYAML==3.12 in /usr/lib/python2.7/site-packages (from License2Deploy==0.3.0)
Requirement already up-to-date: retry==0.9.2 in /usr/lib/python2.7/site-packages (from License2Deploy==0.3.0)
Installing collected packages: License2Deploy
  Found existing installation: License2Deploy 0.3.0
    Uninstalling License2Deploy:
      Successfully uninstalled License2Deploy
  Running setup.py install for License2Deploy
    
    Installing rolling_deploy script to /usr/bin
Successfully installed License2Deploy
Cleaning up...
[INFO    ] {'git+https://github.com/taoistmath/License2Deploy.git@DEVOPS-12154==???': 'Installed'}
[INFO    ] Completed state [git+https://github.com/taoistmath/License2Deploy.git@DEVOPS-12154] at time 15:02:07.761493
```

ran cupdate-service_qa_deploy_ami with force redeploy and saw that new instances remained while old instances were terminated:

![Screen Shot 2019-03-20 at 10 41 56 AM](https://user-images.githubusercontent.com/588833/54706754-e4105380-4afc-11e9-9f3f-a45c08f64737.png)

<img width="908" alt="Screen Shot 2019-03-20 at 10 54 06 AM" src="https://user-images.githubusercontent.com/588833/54707511-81b85280-4afe-11e9-99e4-7fd9b21a7703.png">
