### PR TITLE
DEVOPS-12330: adds check for ASG size of 0

### DIFF
--- a/License2Deploy/rolling_deploy.py
+++ b/License2Deploy/rolling_deploy.py
@@ -162,9 +162,15 @@ class RollingDeploy(object):
       logging.error("Unable to get IP Addresses for instances: {0}".format(e))
       exit(self.exit_error_code)
 
+  def validate_instance_list(self, instances):
+      if len(instances) == 0:
+          raise Exception("There are no instances in this AutoScalingGroup, please check AutoScalingGroup desired capacity.")
+      return True
+
   def get_all_instance_ids(self, group_name):
     """ Gather Instance id's of all instances in the autoscale group """
     instances = [i for i in self.get_group_info(group_name)[0].instances]
+    self.validate_instance_list(instances)
     id_list = [instance_id.instance_id for instance_id in instances]
     return id_list
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 setup(
     name="License2Deploy",
-    version="0.3.2",
+    version="0.3.3",
     author="Dun and Bradstreet",
     author_email="license2deploy@dandb.com",
     description="Rolling deploys by changing desired amount of instances AWS EC2 Autoscale Group",

--- a/tests/rolling_deploy_test.py
+++ b/tests/rolling_deploy_test.py
@@ -303,6 +303,24 @@ class RollingDeployTest(unittest.TestCase):
 
   @mock_ec2_deprecated
   @mock_autoscaling_deprecated
+  @mock_elb_deprecated
+  def test_validate_instance_list(self):
+    self.setUpELB()
+    self.setUpAutoScaleGroup([self.get_autoscaling_configurations(self.GMS_LAUNCH_CONFIGURATION_STG, self.GMS_AUTOSCALING_GROUP_STG)])
+    conn = boto.connect_ec2()
+    reservation = conn.run_instances('ami-1234abcd', min_count=2, private_ip_address="10.10.10.10")
+    instances = reservation.instances
+    self.assertTrue(self.rolling_deploy.validate_instance_list(instances))
+
+  @mock_ec2_deprecated
+  @mock_autoscaling_deprecated
+  @mock_elb_deprecated
+  def test_failure_validate_instance_list(self):
+    instances = []
+    self.assertRaises(Exception, lambda: self.rolling_deploy.validate_instance_list(instances))
+
+  @mock_ec2_deprecated
+  @mock_autoscaling_deprecated
   def test_get_instance_ids_by_requested_build_tag(self):
     self.setUpEC2()
     self.setUpAutoScaleGroup([self.get_autoscaling_configurations(self.GMS_LAUNCH_CONFIGURATION_STG, self.GMS_AUTOSCALING_GROUP_STG)])


### PR DESCRIPTION
Tested by updating ciq on saltmaster to point to this branch, then highstated ciq agent:
```
----------
          ID: License2Deploy
    Function: pip.installed
        Name: git+https://github.com/taoistmath/License2Deploy.git@DEVOPS-12330
      Result: True
     Comment: All packages were successfully installed
     Started: 15:53:25.425225
    Duration: 2087.694 ms
     Changes:   
              ----------
              git+https://github.com/taoistmath/License2Deploy.git@DEVOPS-12330==???:
                  Installed
```

Then ran verified-service_qa_deploy_ami which has ASG desired capacity set to 0 and saw immediate failure:
<img width="1111" alt="Screen Shot 2019-05-16 at 4 03 21 PM" src="https://user-images.githubusercontent.com/588833/57892552-2d76d980-77f4-11e9-95d9-603dc5804d79.png">

passing Travis build:
<img width="1075" alt="Screen Shot 2019-05-17 at 10 52 51 AM" src="https://user-images.githubusercontent.com/588833/57946766-0242c780-7892-11e9-84dc-b459257591a2.png">

Testing evidence that my changes are being tested:
<img width="1101" alt="Screen Shot 2019-05-17 at 1 59 35 PM" src="https://user-images.githubusercontent.com/588833/57955927-15629100-78ac-11e9-8267-01c8a2631f0f.png">
